### PR TITLE
Migrate to modelmeta 0.3.0

### DIFF
--- a/pdp_util/ensemble_members.py
+++ b/pdp_util/ensemble_members.py
@@ -30,7 +30,7 @@ class EnsembleMemberLister(object):
                 #  return a json response with an empty array, consistent with
                 #  the datatype for other ensemble names. OR, possibly better,
                 #  it should return a 404 not found -- because, like, ensemble
-                #  not found. But god only knows what depends on this choice.
+                #  not found. But goodness knows what depends on this choice.
                 start_response('200 OK', [('Content-type','text/plain; charset=utf-8')])
                 return ['']
 

--- a/pdp_util/ensemble_members.py
+++ b/pdp_util/ensemble_members.py
@@ -26,6 +26,11 @@ class EnsembleMemberLister(object):
             ensemble = sesh.query(Ensemble).filter(Ensemble.name == ensemble_name).first()
 
             if not ensemble: # Result does not contain any row therefore ensemble does not exist
+                # TODO: Instead of returning a text/plain response, this should
+                #  return a json response with an empty array, consistent with
+                #  the datatype for other ensemble names. OR, possibly better,
+                #  it should return a 404 not found -- because, like, ensemble
+                #  not found. But god only knows what depends on this choice.
                 start_response('200 OK', [('Content-type','text/plain; charset=utf-8')])
                 return ['']
 

--- a/pdp_util/ensemble_members.py
+++ b/pdp_util/ensemble_members.py
@@ -7,6 +7,7 @@ from numpy import array
 from pdp_util import session_scope
 from modelmeta import *
 
+
 class EnsembleMemberLister(object):
     # TODO: Measure performance with thousands of elements
     def __init__(self, dsn):
@@ -22,23 +23,22 @@ class EnsembleMemberLister(object):
             start_response('400 Bad Request', [])
             return ["Required parameter 'ensemble_name' not specified"]
 
+        JSON_headers = [('Content-type', 'application/json; charset=utf-8')]
         with self.session_scope_factory() as sesh:
             ensemble = sesh.query(Ensemble).filter(Ensemble.name == ensemble_name).first()
 
             if not ensemble: # Result does not contain any row therefore ensemble does not exist
-                # TODO: Instead of returning a text/plain response, this should
-                #  return a json response with an empty array, consistent with
-                #  the datatype for other ensemble names. OR, possibly better,
-                #  it should return a 404 not found -- because, like, ensemble
-                #  not found. But goodness knows what depends on this choice.
-                start_response('200 OK', [('Content-type','text/plain; charset=utf-8')])
-                return ['']
+                start_response('404 Not Found', JSON_headers)
+                return dumps({
+                    "code": 404,
+                    "message": "Not Found",
+                    "details":
+                        "Ensemble named '{}' not found".format(ensemble_name)
+                })
 
             tuples = [x for x in self.list_stuff(ensemble)] # query is lazy load, so must be assigned within scope
 
-        status = '200 OK'
-        response_headers = [('Content-type','application/json; charset=utf-8')]
-        start_response(status, response_headers)
+        start_response('200 OK', JSON_headers)
         d = OrderedDict(sorted(dictify(array(tuples)).items(), key=lambda t:t[0]))
         return dumps(d)
 

--- a/pdp_util/raster.py
+++ b/pdp_util/raster.py
@@ -3,7 +3,7 @@ from os.path import basename
 
 from pydap.wsgi.app import DapServer
 from pdp_util import session_scope
-from modelmeta import DataFile, DataFileVariable, EnsembleDataFileVariables, Ensemble, VariableAlias
+from modelmeta import DataFile, DataFileVariableDSGTimeSeries, EnsembleDataFileVariables, Ensemble, VariableAlias
 
 from simplejson import dumps
 from webob.request import Request
@@ -139,10 +139,10 @@ class RasterMetadata(object):
             return ["Required parameter 'var' not specified"]
 
         with self.session_scope_factory() as sesh:
-            r = sesh.query(DataFileVariable.range_min, DataFileVariable.range_max)\
+            r = sesh.query(DataFileVariableDSGTimeSeries.range_min, DataFileVariableDSGTimeSeries.range_max)\
                 .join(DataFile)\
                 .filter(DataFile.unique_id == unique_id)\
-                .filter(DataFileVariable.netcdf_variable_name == var)
+                .filter(DataFileVariableDSGTimeSeries.netcdf_variable_name == var)
 
         if r.count() == 0: # Result does not contain any row therefore id/var combo does not exist
             start_response('404 Not Found', [])
@@ -180,11 +180,11 @@ class RasterMetadata(object):
             return ["Required parameter 'var' not specified"]
 
         with self.session_scope_factory() as sesh:
-            r = sesh.query(DataFileVariable.range_min, DataFileVariable.range_max, VariableAlias.units)\
+            r = sesh.query(DataFileVariableDSGTimeSeries.range_min, DataFileVariableDSGTimeSeries.range_max, VariableAlias.units)\
                 .join(DataFile)\
                 .join(VariableAlias)\
                 .filter(DataFile.unique_id == unique_id)\
-                .filter(DataFileVariable.netcdf_variable_name == var)
+                .filter(DataFileVariableDSGTimeSeries.netcdf_variable_name == var)
 
         if r.count() == 0: # Result does not contain any row therefore id/var combo does not exist
             start_response('404 Not Found', [])
@@ -232,5 +232,5 @@ def db_raster_configurator(session, name, version, api_version, ensemble, root_u
     return config
 
 def ensemble_files(session, ensemble_name):
-    q = session.query(DataFile).join(DataFileVariable).join(EnsembleDataFileVariables).join(Ensemble).filter(Ensemble.name == ensemble_name)
+    q = session.query(DataFile).join(DataFileVariableDSGTimeSeries).join(EnsembleDataFileVariables).join(Ensemble).filter(Ensemble.name == ensemble_name)
     return { row.unique_id: row.filename for row in q }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Pillow==5.4.1
 PyCDS==2.2.1
 PyYAML==3.13
 WebOb==1.8.5
-modelmeta==0.0.5
+modelmeta==0.3.0
 numpy==1.16.0
 pydap-pdp==3.2.2
 pydap.handlers.pcic==0.0.7

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     url="http://www.pacificclimate.org/",
     author="James Hiebert",
     author_email="hiebert@uvic.ca",
+    # TODO: Should we adhere to policy: no version numbers in setup.py requirements?
     install_requires=['webob',
                       'openid2rp',
                       'genshi',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
                       # raster portal stuff
                       'pydap_pdp >=3.2.1',
                       'pydap.handlers.pcic >=0.0.3',
-                      'modelmeta >=0.0.5',
+                      'modelmeta >=0.3.0',
                       'PyYAML'
                       ],
     tests_require=['pytest',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     url="http://www.pacificclimate.org/",
     author="James Hiebert",
     author_email="hiebert@uvic.ca",
-    # TODO: Should we adhere to policy: no version numbers in setup.py requirements?
     install_requires=['webob',
                       'openid2rp',
                       'genshi',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,43 +121,6 @@ def mm_empty_session(mm_engine, mm_schema_name):
 
 # Database test objects
 
-# Overview
-#
-# We set up the following objects which can be added to the database:
-#
-# model_1: Model
-#
-# emission_1: Emission
-# emission_2: Emission
-#
-# run_11: Run(model_1, emission_1)
-# run_12: Run(model_1, emission_2)
-#
-# data_file_1: DataFile(run_11)
-# data_file_2: DataFile(run_12)
-# data_file_3: DataFile(run_11)
-#
-# variable_alias_1: VariableAlias
-# variable_alias_2: VariableAlias
-#
-# dfv_dsg_time_series_11:
-#   DataFileVariableDSGTimeSeries(data_file_1, variable_alias_1)
-# dfv_dsg_time_series_12:
-#   DataFileVariableDSGTimeSeries(data_file_1, variable_alias_2)
-# dfv_dsg_time_series_21:
-#   DataFileVariableDSGTimeSeries(data_file_2, variable_alias_2)
-# dfv_dsg_time_series_31:
-#   DataFileVariableDSGTimeSeries(data_file_3, variable_alias_2)
-#
-# ensemble_1: Ensemble
-#   dfv_dsg_time_series_11
-#   dfv_dsg_time_series_21
-#
-# ensemble_2: Ensemble
-#   dfv_dsg_time_series_21
-#   dfv_dsg_time_series_31
-
-
 # Model
 
 def make_model(i):
@@ -267,7 +230,7 @@ def variable_alias_2():
 
 # DataFileVariableDSGTimeSeries
 
-def make_test_dfv_dsg_time_series(i, file=None, variable_alias=None):
+def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
     return DataFileVariableDSGTimeSeries(
         id=i,
         derivation_method='derivation_method_{}'.format(i),
@@ -283,25 +246,25 @@ def make_test_dfv_dsg_time_series(i, file=None, variable_alias=None):
 
 @pytest.fixture(scope='function')
 def dfv_dsg_time_series_11(data_file_1, variable_alias_1):
-    return make_test_dfv_dsg_time_series(
+    return make_dfv_dsg_time_series(
         1, file=data_file_1, variable_alias=variable_alias_1)
 
 
 @pytest.fixture(scope='function')
 def dfv_dsg_time_series_12(data_file_1, variable_alias_2):
-    return make_test_dfv_dsg_time_series(
+    return make_dfv_dsg_time_series(
         2, file=data_file_1, variable_alias=variable_alias_2)
 
 
 @pytest.fixture(scope='function')
 def dfv_dsg_time_series_21(data_file_2, variable_alias_1):
-    return make_test_dfv_dsg_time_series(
+    return make_dfv_dsg_time_series(
         3, file=data_file_2, variable_alias=variable_alias_1)
 
 
 @pytest.fixture(scope='function')
 def dfv_dsg_time_series_31(data_file_3, variable_alias_1):
-    return make_test_dfv_dsg_time_series(
+    return make_dfv_dsg_time_series(
         4, file=data_file_3, variable_alias=variable_alias_1)
 
 
@@ -391,6 +354,43 @@ def objects_subset(object_dict, subset):
     )
 
 
+# Overview
+#
+# We set up the following objects which can be added to the database:
+#
+# model_1: Model
+#
+# emission_1: Emission
+# emission_2: Emission
+#
+# run_11: Run(model_1, emission_1)
+# run_12: Run(model_1, emission_2)
+#
+# data_file_1: DataFile(run_11)
+# data_file_2: DataFile(run_12)
+# data_file_3: DataFile(run_11)
+#
+# variable_alias_1: VariableAlias
+# variable_alias_2: VariableAlias
+#
+# dfv_dsg_time_series_11: 0
+#   DataFileVariableDSGTimeSeries(data_file_1 0, variable_alias_1)
+# dfv_dsg_time_series_12: 1
+#   DataFileVariableDSGTimeSeries(data_file_1 0, variable_alias_2)
+# dfv_dsg_time_series_21: 2
+#   DataFileVariableDSGTimeSeries(data_file_2 1, variable_alias_2)
+# dfv_dsg_time_series_31: 3
+#   DataFileVariableDSGTimeSeries(data_file_3 2, variable_alias_2)
+#
+# ensemble_1: Ensemble
+#   dfv_dsg_time_series_11
+#   dfv_dsg_time_series_21
+#
+# ensemble_2: Ensemble
+#   dfv_dsg_time_series_21
+#   dfv_dsg_time_series_31
+
+
 @pytest.fixture(scope="function")
 def mm_all_database_objects():
     """Return an ordered dict full of *newly created* database objects.
@@ -413,11 +413,11 @@ def mm_all_database_objects():
     ])
     data_files = make(make_data_file, [runs[0], runs[1], runs[0]])
     variable_aliases = make(make_variable_alias, 2)
-    dfv_dsg_tss = make(make_test_dfv_dsg_time_series, [
-        (data_files[0], variable_aliases[0]),
-        (data_files[0], variable_aliases[1]),
-        (data_files[1], variable_aliases[1]),
-        (data_files[2], variable_aliases[1]),
+    dfv_dsg_tss = make(make_dfv_dsg_time_series, [
+        (data_files[0], variable_aliases[0]),   # var 0, uid 0
+        (data_files[0], variable_aliases[1]),   # var 1, uid 0
+        (data_files[1], variable_aliases[1]),   # var 2, uid 1
+        (data_files[2], variable_aliases[1]),   # var 3, uid 2
     ])
     ensembles = make(make_ensemble, 3)
     ensemble_dfvs = make(make_ensemble_dfvs, [
@@ -435,7 +435,7 @@ def mm_all_database_objects():
         ('data_files', data_files),
         ('variable_aliases', variable_aliases),
         ('dfv_dsg_tss', dfv_dsg_tss),
-        ('ensembles', ensembles),  # Leave out 3rd so that we have a not found ensemble
+        ('ensembles', ensembles),
         ('ensemble_dfvs', ensemble_dfvs),        
     ])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,10 +244,7 @@ def mm_all_database_objects():
     An ordered dict because order of insertion (and deletion) in database 
     matters.
 
-    Newly created objects because attempting delete and then re-insert the same
-    SQLAlchemy object causes an error. And regrettably these objects, when
-    made transient as advised by SQLAlchemy, lose all their attribute values.
-    So new objects it is.
+    Newly created objects because ... see Note 2 above.
     """
     models = make(make_model, 2)
     emissions = make(make_emission, 2)
@@ -383,14 +380,9 @@ def mm_test_session(mm_empty_session, mm_test_session_objects):
 # TODO: Consider substituting delete actions for rollback everywhere
 @pytest.fixture(scope="function")
 def mm_test_session_committed(mm_test_session, mm_test_session_objects):
-    # Contents of an uncommitted session can only be seen by that session;
-    # i.e., a session is implicitly in a transaction. This is good.
-    # Some components of pdp_util, e.g., EnsembleCatalog, creates an
-    # independent engine and session to access the database, so we must commit
-    # our session contents.
-    # However, committing a session leaves gunk in the database that can
-    # mess up the database setup for other tests. Hence we have to clean up
-    # after ourselves. And commit that cleanup.
+    """Fully committed test database. For an explanation of why, see
+    Note 1 above.
+    """
 
     s = mm_test_session
     s.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -448,16 +448,6 @@ def raster_metadata(mm_database_dsn):
     return RasterMetadata(mm_database_dsn)
 
 
-@pytest.fixture(scope="function")
-def mm_session():
-    return modelmeta.test_session()
-
-
-@pytest.fixture(scope="function")
-def mm_dsn():
-    return modelmeta.test_dsn
-
-
 # Helper functions as fixtures
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def test_session(empty_session):
 def conn_params(test_session):
     yield test_session.get_bind().url
 
+
 #######################################################################
 # Test fixtures for code dependent on modelmeta database
 
@@ -85,7 +86,7 @@ def mm_engine():
         engine.dispose()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def mm_empty_session(mm_engine):
     """Single-test database session. All session actions are rolled back on teardown"""
     session = sessionmaker(bind=mm_engine)()
@@ -261,14 +262,15 @@ def mm_test_session(
     ensemble_dfvs_1,
     ensemble_dfvs_2,
 ):
-    mm_empty_session.add_all([ensemble1, ensemble2])
-    mm_empty_session.flush()
-    mm_empty_session.add_all([dfv_dsg_time_series_11, dfv_dsg_time_series_12])
-    mm_empty_session.flush()
-    mm_empty_session.add_all(ensemble_dfvs_1)
-    mm_empty_session.add_all(ensemble_dfvs_2)
-    mm_empty_session.flush()
-    yield mm_empty_session
+    s = mm_empty_session
+    s.add_all([ensemble1, ensemble2])
+    s.flush()
+    s.add_all([dfv_dsg_time_series_11, dfv_dsg_time_series_12])
+    s.flush()
+    s.add_all(ensemble_dfvs_1)
+    s.add_all(ensemble_dfvs_2)
+    s.flush()
+    yield s
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,8 +453,10 @@ def raster_metadata(mm_database_dsn):
 
 @pytest.fixture(scope="session")
 def query_params():
-    """Returns a query parameter string formed from name-value pairs."""
-    def f(nv_pairs):
+    """Returns a query parameter string formed from name-value pairs.
+    Each pair is an argument; any number may be provided.
+    """
+    def f(*nv_pairs):
         return '?' + '&'.join(
             '{}={}'.format(name, value)
             for name, value in nv_pairs if value is not None
@@ -467,20 +469,16 @@ def test_wsgi_app():
     """Generic WSGI app test
     Note: It's OK to name a fixture with test_
     """
-    def f(app, url, status, content_type, keys):
+    def f(app, url, status, content_type):
         req = Request.blank(url)
         resp = req.get_response(app)
 
         assert resp.status == status
-        if status != '200 OK':
-            return resp
-
         assert resp.content_type == content_type
-        if content_type != 'application/json':
-            return resp
 
-        body = json.loads(resp.body)
-        if keys is not None:
-            assert set(body.keys()) == keys
-        return body
+        if content_type != 'application/json':
+            return resp, None
+
+        json_body = json.loads(resp.body)
+        return resp, json_body
     return f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def ensemble2():
 def make_data_file(i, run=None, timeset=None):
     return DataFile(
         id=i,
-        filename='data_file_{}'.format(i),
+        filename='/storage/data_file_{}'.format(i),
         first_1mib_md5sum='first_1mib_md5sum',
         unique_id='unique_id_{}'.format(i),
         x_dim_name='lon',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,50 +297,69 @@ def mm_test_session_objects(mm_all_database_objects):
         ])
     )
 
+
 # Fixtures returning database objects.
+
+def get_database_object(objects, obj_type, obj_index):
+    if obj_type is None or obj_index is None:
+        return None
+    return objects[obj_type][obj_index]
+
+
+@pytest.fixture(scope='function')
+def database_object(request, mm_all_database_objects):
+    return get_database_object(mm_all_database_objects, *request.param)
+
+
 # It would be nice (and apparently simple) to reduce the repetition here,
 # but calling @pytest.fixture in a loop doesn't work -- it replaces the
 # previous fixture(s) rather than creating several of them. Rats.
 
-@pytest.fixture(scope='function')
-def database_object(request, mm_all_database_objects):
-    obj_type, obj_index = request.param
-    return mm_all_database_objects[obj_type][obj_index]
-
-
 @pytest.fixture(scope='function', name="model")
 def fixture_model(request, mm_all_database_objects):
-    return mm_all_database_objects['models'][request.param]
+    return get_database_object(
+        mm_all_database_objects, 'models', request.param
+    )
 
 
 @pytest.fixture(scope='function', name="emission")
 def fixture_emission(request, mm_all_database_objects):
-    return mm_all_database_objects['emissions'][request.param]
+    return get_database_object(
+        mm_all_database_objects, 'emissions', request.param
+    )
 
 
 @pytest.fixture(scope='function', name="run")
 def fixture_run(request, mm_all_database_objects):
-    return mm_all_database_objects['runs'][request.param]
+    return get_database_object(mm_all_database_objects, 'runs', request.param)
 
 
 @pytest.fixture(scope='function', name="data_file")
 def fixture_data_file(request, mm_all_database_objects):
-    return mm_all_database_objects['data_files'][request.param]
+    return get_database_object(
+        mm_all_database_objects, 'data_files', request.param
+    )
 
 
 @pytest.fixture(scope='function', name="variable_alias")
 def fixture_variable_alias(request, mm_all_database_objects):
-    return mm_all_database_objects['variable_aliases'][request.param]
+    return get_database_object(
+        mm_all_database_objects, 'variable_aliases', request.param
+    )
 
 
 @pytest.fixture(scope='function', name="ensemble")
 def fixture_ensemble(request, mm_all_database_objects):
-    return mm_all_database_objects['ensembles'][request.param]
+    return get_database_object(
+        mm_all_database_objects, 'ensembles', request.param
+    )
 
 
 @pytest.fixture(scope='function', name="ensemble_dfv")
 def fixture_ensemble_dfv(request, mm_all_database_objects):
-    return mm_all_database_objects['ensemble_dfvs'][request.param]
+    return get_database_object(
+        mm_all_database_objects, 'ensemble_dfvs', request.param
+    )
 
 
 # Database sessions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from pkg_resources import resource_filename
 
@@ -5,6 +6,13 @@ import pytest
 import pycds
 from pycds import Network, Contact, Station, History, Variable
 import modelmeta
+from modelmeta import (
+    Ensemble,
+    DataFile,
+    DataFileVariableDSGTimeSeries,
+    VariableAlias,
+    EnsembleDataFileVariables,
+)
 import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -60,6 +68,207 @@ def test_session(empty_session):
 @pytest.fixture(scope="function")
 def conn_params(test_session):
     yield test_session.get_bind().url
+
+#######################################################################
+# Test fixtures for code dependent on modelmeta database
+
+# TODO: Factor out common engine creation
+@pytest.fixture(scope='session')
+def mm_engine():
+    """Test-session-wide database engine"""
+    with testing.postgresql.Postgresql() as pg:
+        engine = create_engine(pg.url())
+        engine.execute("create extension postgis")
+        engine.execute(CreateSchema('test_meta'))
+        modelmeta.Base.metadata.create_all(bind=engine)
+        yield engine
+        engine.dispose()
+
+
+@pytest.fixture(scope='session')
+def mm_empty_session(mm_engine):
+    """Single-test database session. All session actions are rolled back on teardown"""
+    session = sessionmaker(bind=mm_engine)()
+    # Default search path is `"$user", public`. Need to reset that to search crmp (for our db/orm content) and
+    # public (for postgis functions)
+    session.execute('SET search_path TO test_meta, public')
+    # print('\nsearch_path', [r for r in session.execute('SHOW search_path')])
+    yield session
+    session.rollback()
+    session.close()
+
+
+# Ensemble
+
+def make_ensemble(id):
+    return Ensemble(
+        id=id,
+        changes='wonder what this is for',
+        description='Ensemble {}'.format(id),
+        name='ensemble{}'.format(id),
+        version=float(id)
+    )
+
+
+@pytest.fixture(scope='function')
+def ensemble1():
+    return make_ensemble(1)
+
+
+@pytest.fixture(scope='function')
+def ensemble2():
+    return make_ensemble(2)
+
+
+# DataFile
+
+def make_data_file(i, run=None, timeset=None):
+    return DataFile(
+        id=i,
+        filename='data_file_{}'.format(i),
+        first_1mib_md5sum='first_1mib_md5sum',
+        unique_id='unique_id_{}'.format(i),
+        x_dim_name='lon',
+        y_dim_name='lat',
+        t_dim_name='time',
+        index_time=datetime.datetime.now(),
+        run=run,
+        timeset=timeset,
+    )
+
+
+@pytest.fixture(scope='function')
+def data_file_1():
+    return make_data_file(1)
+
+
+@pytest.fixture(scope='function')
+def data_file_2():
+    return make_data_file(2)
+
+
+@pytest.fixture(scope='function')
+def data_file_3():
+    return make_data_file(3)
+
+
+# VariableAlias
+
+def make_variable_alias(i):
+    return VariableAlias(
+        long_name='long_name_{}'.format(i),
+        standard_name='standard_name_{}'.format(i),
+        units='units_{}'.format(i),
+    )
+
+
+@pytest.fixture(scope='function')
+def variable_alias_1():
+    return make_variable_alias(1)
+
+
+@pytest.fixture(scope='function')
+def variable_alias_2():
+    return make_variable_alias(2)
+
+
+# DataFileVariableDSGTimeSeries
+
+def make_test_dfv_dsg_time_series(i, file=None, variable_alias=None):
+    return DataFileVariableDSGTimeSeries(
+        id=i,
+        derivation_method='derivation_method_{}'.format(i),
+        variable_cell_methods='variable_cell_methods_{}'.format(i),
+        netcdf_variable_name='var_{}'.format(i),
+        disabled=False,
+        range_min=0,
+        range_max=100,
+        file=file,
+        variable_alias=variable_alias,
+    )
+
+
+@pytest.fixture(scope='function')
+def dfv_dsg_time_series_11(data_file_1, variable_alias_1):
+    return make_test_dfv_dsg_time_series(
+        1, file=data_file_1, variable_alias=variable_alias_1)
+
+
+@pytest.fixture(scope='function')
+def dfv_dsg_time_series_12(data_file_1, variable_alias_2):
+    return make_test_dfv_dsg_time_series(
+        2, file=data_file_1, variable_alias=variable_alias_2)
+
+
+@pytest.fixture(scope='function')
+def dfv_dsg_time_series_21(data_file_2, variable_alias_1):
+    return make_test_dfv_dsg_time_series(
+        3, file=data_file_2, variable_alias=variable_alias_1)
+
+
+@pytest.fixture(scope='function')
+def dfv_dsg_time_series_31(data_file_3, variable_alias_1):
+    return make_test_dfv_dsg_time_series(
+        4, file=data_file_3, variable_alias=variable_alias_1)
+
+
+# EnsembleDataFileVariables: tag DFVs with Ensembles
+
+def make_ensemble_dfvs(ensemble, dfv):
+    return EnsembleDataFileVariables(
+        ensemble_id=ensemble.id,
+        data_file_variable_id=dfv.id,
+    )
+
+
+@pytest.fixture(scope='function')
+def ensemble_dfvs_1(ensemble1, dfv_dsg_time_series_11, dfv_dsg_time_series_21):
+    return [
+        make_ensemble_dfvs(ensemble1, dfv_dsg_time_series_11),
+        make_ensemble_dfvs(ensemble1, dfv_dsg_time_series_21),
+    ]
+
+
+# TODO: Make this, or something like it, drive ensemble_dfvs_1
+@pytest.fixture(scope='function')
+def ensemble1_data_files(data_file_1, data_file_2):
+    return {data_file_1, data_file_2}
+
+
+@pytest.fixture(scope='function')
+def ensemble_dfvs_2(ensemble2, dfv_dsg_time_series_21, dfv_dsg_time_series_31):
+    return [
+        make_ensemble_dfvs(ensemble2, dfv_dsg_time_series_21),
+        make_ensemble_dfvs(ensemble2, dfv_dsg_time_series_31),
+    ]
+
+
+# TODO: Make this, or something like it, drive ensemble_dfvs_2
+@pytest.fixture(scope='function')
+def ensemble2_data_files(data_file_3, data_file_2):
+    return {data_file_2, data_file_3}
+
+
+# Database sessions
+
+@pytest.fixture(scope="function")
+def mm_test_session(
+    mm_empty_session,
+    ensemble1,
+    ensemble2,
+    dfv_dsg_time_series_11,
+    dfv_dsg_time_series_12,
+    ensemble_dfvs_1,
+    ensemble_dfvs_2,
+):
+    mm_empty_session.add_all([ensemble1, ensemble2])
+    mm_empty_session.flush()
+    mm_empty_session.add_all([dfv_dsg_time_series_11, dfv_dsg_time_series_12])
+    mm_empty_session.flush()
+    mm_empty_session.add_all(ensemble_dfvs_1)
+    mm_empty_session.add_all(ensemble_dfvs_2)
+    mm_empty_session.flush()
+    yield mm_empty_session
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,6 @@ def mm_empty_session(mm_engine, mm_schema_name):
 
 def make_model(i):
     return Model(
-        id=i,
         short_name='model_{}'.format(i),
         type='model_type'
     )
@@ -129,14 +128,12 @@ def make_model(i):
 
 def make_emission(i):
     return Emission(
-        id=i,
         short_name='emission_{}'.format(i),
     )
 
 
 def make_run(i, model, emission):
     return Run(
-        id=i,
         name='emission_{}'.format(i),
         model=model,
         emission=emission,
@@ -145,7 +142,6 @@ def make_run(i, model, emission):
 
 def make_data_file(i, run=None, timeset=None):
     return DataFile(
-        id=i,
         filename='/storage/data_file_{}.nc'.format(i),
         first_1mib_md5sum='first_1mib_md5sum',
         unique_id='unique_id_{}'.format(i),
@@ -168,7 +164,6 @@ def make_variable_alias(i):
 
 def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
     return DataFileVariableDSGTimeSeries(
-        id=i,
         derivation_method='derivation_method_{}'.format(i),
         variable_cell_methods='variable_cell_methods_{}'.format(i),
         netcdf_variable_name='var_{}'.format(i),
@@ -180,21 +175,13 @@ def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
     )
 
 
-def make_ensemble(id, data_file_variables):
+def make_ensemble(i, data_file_variables):
     return Ensemble(
-        id=id,
         changes='wonder what this is for',
-        description='Ensemble {}'.format(id),
-        name='ensemble_{}'.format(id),
-        version=float(id),
+        description='Ensemble {}'.format(i),
+        name='ensemble_{}'.format(i),
+        version=float(i),
         data_file_variables=data_file_variables,
-    )
-
-
-def make_ensemble_dfvs(ensemble, dfv):
-    return EnsembleDataFileVariables(
-        ensemble_id=ensemble.id,
-        data_file_variable_id=dfv.id,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,15 +475,20 @@ def query_params():
 @pytest.fixture(scope="session")
 def test_wsgi_app():
     # It's OK to name a fixture with test_
-    def f(app, qps, status, keys):
+    def f(app, qps, status, content_type, keys):
         req = Request.blank('?{}'.format(qps))
         resp = req.get_response(app)
 
         assert resp.status == status
         if status != '200 OK':
-            return
+            return resp
 
-        assert resp.content_type == 'application/json'
+        assert resp.content_type == content_type
+        if content_type != 'application/json':
+            return resp
+
         body = json.loads(resp.body)
-        assert set(body.keys()) == keys
+        if keys is not None:
+            assert set(body.keys()) == keys
+        return body
     return f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def mm_empty_session(mm_engine, mm_schema_name):
     All session actions are rolled back on teardown"""
     session = sessionmaker(bind=mm_engine)()
     session.execute(
-        'SET search_path TO test_meta, public'.format(mm_schema_name)
+        'SET search_path TO {}, public'.format(mm_schema_name)
     )
     yield session
     session.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,7 @@ def mm_test_session_objects(
 def mm_test_session(mm_empty_session, mm_test_session_objects):
     s = mm_empty_session
     for obj in mm_test_session_objects:
-        print('### mm_test_session: add', obj)
+        # print('### mm_test_session: add', obj)
         s.add(obj)
         s.flush()
     yield s
@@ -319,28 +319,33 @@ def mm_test_session_committed(mm_test_session, mm_test_session_objects):
     # after ourselves. And commit that cleanup.
 
     s = mm_test_session
-    print('### mm_test_session_committed: setup commit')
+    # print('### mm_test_session_committed: setup commit')
     s.commit()
     yield s
     for obj in reversed(mm_test_session_objects):
-        print('### mm_test_session_committed: delete', obj)
+        # print('### mm_test_session_committed: delete', obj)
         s.delete(obj)
         s.flush()
-    print('### mm_test_session_committed: teardown commit')
+    # print('### mm_test_session_committed: teardown commit')
     s.commit()
 
+
+# WSGI apps
 
 @pytest.fixture(scope="function")
 def ensemble_member_lister():
     return EnsembleMemberLister(modelmeta.test_dsn)
 
+
 @pytest.fixture(scope="function")
-def raster_metadata():
-    return RasterMetadata(modelmeta.test_dsn)
+def raster_metadata(mm_database_dsn):
+    return RasterMetadata(mm_database_dsn)
+
 
 @pytest.fixture(scope="function")
 def mm_session():
     return modelmeta.test_session()
+
 
 @pytest.fixture(scope="function")
 def mm_dsn():

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -2,10 +2,11 @@ import pytest
 
 
 @pytest.mark.parametrize('ensemble, status, content_type, keys', [
-    ('ensemble_1', '200 OK', 'application/json', {'emission_1', 'emission_2'}),
-    ('non_existent', '404 Not Found', 'application/json', None),
-    (None, '400 Bad Request', None, None),
-])
+    (0, '200 OK', 'application/json', {'emission_0', 'emission_1'}),
+    (1, '200 OK', 'application/json', {'emission_0', 'emission_1'}),
+    (2, '404 Not Found', 'application/json', None),
+    # (None, '400 Bad Request', None, None),
+], indirect=['ensemble'])
 @pytest.mark.usefixtures('mm_test_session_committed')
 def test_ensemble_member_lister(
     ensemble_member_lister,
@@ -16,7 +17,7 @@ def test_ensemble_member_lister(
     content_type,
     keys,
 ):
-    url = query_params(('ensemble_name', ensemble))
+    url = query_params(('ensemble_name', ensemble.name))
     resp, body = \
         test_wsgi_app(ensemble_member_lister, url, status, content_type)
     if keys is not None:
@@ -24,4 +25,4 @@ def test_ensemble_member_lister(
     if status[:3] == '404':
         assert body['code'] == 404
         assert body['message'] == 'Not Found'
-        assert ensemble in body['details']
+        assert ensemble.name in body['details']

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -16,7 +16,7 @@ def test_ensemble_member_lister(
     content_type,
     keys,
 ):
-    qps = query_params((('ensemble_name', ensemble),))
-    resp = test_wsgi_app(ensemble_member_lister, qps, status, content_type, keys)
+    url = query_params((('ensemble_name', ensemble),))
+    resp = test_wsgi_app(ensemble_member_lister, url, status, content_type, keys)
     if ensemble == 'non_existent':
         assert resp.body == ''

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-# TODO: enable None case
 @pytest.mark.parametrize('ensemble, status, content_type', [
     (0, '200 OK', 'application/json'),
     (1, '200 OK', 'application/json'),

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,27 +1,22 @@
-from webob.request import Request
-from simplejson import loads
-
-def test_ensemble_member_lister(ensemble_member_lister):
-    req = Request.blank('?ensemble_name=bcsd_downscale_canada')
-    resp = req.get_response(ensemble_member_lister)
-
-    assert resp.status == '200 OK'
-    assert resp.content_type == 'application/json'
-    
-    ensembles = loads(resp.body)
-    # Good enough
-    assert len(ensembles) == 3
-    assert set(ensembles.keys()) == set(['historical+rcp85', 'historical+rcp45', 'historical+rcp26'])
-
-def test_ensemble_bad_request(ensemble_member_lister):
-    req = Request.blank('')
-    resp = req.get_response(ensemble_member_lister)
-    assert resp.status == '400 Bad Request'
+import pytest
 
 
-def test_ensemble_does_not_exist(ensemble_member_lister):
-    req = Request.blank('?ensemble_name=non_existant')
-    resp = req.get_response(ensemble_member_lister)
-
-    assert resp.status == '200 OK'
-    assert resp.body == ''
+@pytest.mark.parametrize('ensemble, status, content_type, keys', [
+    ('ensemble_1', '200 OK', 'application/json', {'emission_1', 'emission_2'}),
+    ('non_existent', '200 OK', 'text/plain', None),
+    (None, '400 Bad Request', None, None),
+])
+@pytest.mark.usefixtures('mm_test_session_committed')
+def test_ensemble_member_lister(
+    ensemble_member_lister,
+    test_wsgi_app,
+    query_params,
+    ensemble,
+    status,
+    content_type,
+    keys,
+):
+    qps = query_params((('ensemble_name', ensemble),))
+    resp = test_wsgi_app(ensemble_member_lister, qps, status, content_type, keys)
+    if ensemble == 'non_existent':
+        assert resp.body == ''

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -6,7 +6,7 @@ import pytest
     (0, '200 OK', 'application/json'),
     (1, '200 OK', 'application/json'),
     (2, '404 Not Found', 'application/json'),
-    # (None, '400 Bad Request', None, None),
+    (None, '400 Bad Request', None),
 ], indirect=['ensemble'])
 @pytest.mark.usefixtures('mm_test_session_committed')
 def test_ensemble_member_lister(
@@ -17,7 +17,7 @@ def test_ensemble_member_lister(
     status,
     content_type,
 ):
-    url = query_params(('ensemble_name', ensemble.name))
+    url = query_params(('ensemble_name', ensemble and ensemble.name))
     resp, body = \
         test_wsgi_app(ensemble_member_lister, url, status, content_type)
     if status[:3] == '200':

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,10 +1,11 @@
 import pytest
 
 
-@pytest.mark.parametrize('ensemble, status, content_type, keys', [
-    (0, '200 OK', 'application/json', {'emission_0', 'emission_1'}),
-    (1, '200 OK', 'application/json', {'emission_0', 'emission_1'}),
-    (2, '404 Not Found', 'application/json', None),
+# TODO: enable None case
+@pytest.mark.parametrize('ensemble, status, content_type', [
+    (0, '200 OK', 'application/json'),
+    (1, '200 OK', 'application/json'),
+    (2, '404 Not Found', 'application/json'),
     # (None, '400 Bad Request', None, None),
 ], indirect=['ensemble'])
 @pytest.mark.usefixtures('mm_test_session_committed')
@@ -15,13 +16,15 @@ def test_ensemble_member_lister(
     ensemble,
     status,
     content_type,
-    keys,
 ):
     url = query_params(('ensemble_name', ensemble.name))
     resp, body = \
         test_wsgi_app(ensemble_member_lister, url, status, content_type)
-    if keys is not None:
-        assert set(body.keys()) == keys
+    if status[:3] == '200':
+        data_files = {dfv.file for dfv in ensemble.data_file_variables}
+        runs = {df.run for df in data_files}
+        emissions = {run.emission for run in runs}
+        assert set(body.keys()) == {e.short_name for e in emissions}
     if status[:3] == '404':
         assert body['code'] == 404
         assert body['message'] == 'Not Found'

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -6,31 +6,31 @@ import pytest
 from webob.request import Request
 
 
-def test_ensemble1_files(mm_test_session, ensemble1, ensemble1_data_files):
-    result = ensemble_files(mm_test_session, ensemble1.name)
-    assert result == {df.unique_id: df.filename for df in ensemble1_data_files}
+def test_ensemble_1_files(mm_test_session, ensemble_1, ensemble_1_data_files):
+    result = ensemble_files(mm_test_session, ensemble_1.name)
+    assert result == {df.unique_id: df.filename for df in ensemble_1_data_files}
 
 
-def test_ensemble2_files(mm_test_session, ensemble2, ensemble2_data_files):
-    result = ensemble_files(mm_test_session, ensemble2.name)
-    assert result == {df.unique_id: df.filename for df in ensemble2_data_files}
+def test_ensemble_2_files(mm_test_session, ensemble_2, ensemble_2_data_files):
+    result = ensemble_files(mm_test_session, ensemble_2.name)
+    assert result == {df.unique_id: df.filename for df in ensemble_2_data_files}
 
 
 @pytest.mark.parametrize('root_url', ['foo/', 'bar/'])
 def test_db_raster_catalog(
-    mm_test_session, ensemble1, ensemble1_data_files, root_url
+    mm_test_session, ensemble_1, ensemble_1_data_files, root_url
 ):
-    result = db_raster_catalog(mm_test_session, ensemble1.name, root_url)
+    result = db_raster_catalog(mm_test_session, ensemble_1.name, root_url)
     assert result == {
         df.unique_id: '{}{}'.format(root_url, basename(df.filename))
-        for df in ensemble1_data_files
+        for df in ensemble_1_data_files
     }
 
 
 @pytest.mark.parametrize(
     'name, version, api_version, ensemble, root_url, handlers',
     [
-        ('A name', 'Version 0.0.0.1', '0.0', 'ensemble1', 'http://root.ca/',
+        ('A name', 'Version 0.0.0.1', '0.0', 'ensemble_1', 'http://root.ca/',
          [
              {'url': 'data_file_1.nc', 'file': '/storage/data_file_1.nc'},
              {'url': 'data_file_2.nc', 'file': '/storage/data_file_2.nc'},
@@ -65,13 +65,13 @@ def test_db_raster_configurator(
 @pytest.mark.usefixtures('mm_test_session_committed')
 def test_ensemble_catalog(
     mm_database_dsn,
-    ensemble1,
-    ensemble1_data_files,
+    ensemble_1,
+    ensemble_1_data_files,
     root_url,
     url
 ):
     config = {
-        'ensemble': ensemble1.name,
+        'ensemble': ensemble_1.name,
         'root_url': root_url,
     }
     app = EnsembleCatalog(mm_database_dsn, config)
@@ -82,7 +82,7 @@ def test_ensemble_catalog(
     body = json.loads(resp.body)
     assert body == {
         df.unique_id: '{}{}'.format(root_url, basename(df.filename))
-        for df in ensemble1_data_files
+        for df in ensemble_1_data_files
     }
 
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -52,17 +52,28 @@ def test_db_raster_configurator(
     )
 
 
-def test_db_raster_configurator_handlers(mm_session):
-    # Handlers must be tested seperately because they are a list and order cannot be guaranteed on database query
-    args = [mm_session, 'A name', 'Version 0.0.0.1', '0.0', 'bc_prism', 'http://basalt.pcic.uvic.ca:8080/data/']
-    handlers = [{'url': 'tmax_monClim_PRISM_historical_run1_197101-200012.nc',
-                 'file': '/home/data/climate/PRISM/dataportal/tmax_monClim_PRISM_historical_run1_197101-200012.nc'},
-                {'url': 'pr_monClim_PRISM_historical_run1_197101-200012.nc',
-                 'file': '/home/data/climate/PRISM/dataportal/pr_monClim_PRISM_historical_run1_197101-200012.nc'},
-                {'url': 'tmin_monClim_PRISM_historical_run1_197101-200012.nc',
-                 'file': '/home/data/climate/PRISM/dataportal/tmin_monClim_PRISM_historical_run1_197101-200012.nc'}]
-    result = db_raster_configurator(*args)
-    assert all([x in result['handlers'] for x in handlers])
+@pytest.mark.parametrize(
+    'name, version, api_version, ensemble, root_url, handlers',
+    [
+        ('A name', 'Version 0.0.0.1', '0.0', 'ensemble1', 'http://root.ca',
+         [
+             {'url': 'data_file_1', 'file': '/storage/data_file_1'},
+             {'url': 'data_file_2', 'file': '/storage/data_file_2'},
+         ]),
+])
+def test_db_raster_configurator_handlers(
+    mm_test_session, name, version, api_version, ensemble, root_url, handlers,
+):
+    # Handlers must be tested seperately because they are a list and order
+    # cannot be guaranteed on database query
+    result = db_raster_configurator(
+        mm_test_session, name, version, api_version, ensemble, root_url,
+    )
+    print('### handlers', result['handlers'])
+    assert all(
+        x in result['handlers']
+        for x in handlers
+    )
 
 
 @pytest.mark.parametrize('url', ['', '/url/is/irrellevant'])

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -19,11 +19,15 @@ def test_ensemble2_files(mm_test_session, ensemble2, ensemble2_data_files):
     assert result == {df.unique_id: df.filename for df in ensemble2_data_files}
 
 
-def test_db_raster_catalog(mm_session, config):
-    result = db_raster_catalog(mm_session, config['ensemble'], config['root_url'])
-    assert result == {'tmax_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/tmax_monClim_PRISM_historical_run1_197101-200012.nc',
-                      'pr_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/pr_monClim_PRISM_historical_run1_197101-200012.nc',
-                      'tmin_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/tmin_monClim_PRISM_historical_run1_197101-200012.nc'}
+@pytest.mark.parametrize('root_url', ['foo/', 'bar/'])
+def test_db_raster_catalog(
+    mm_test_session, ensemble1, ensemble1_data_files, root_url
+):
+    result = db_raster_catalog(mm_test_session, ensemble1.name, root_url)
+    assert result == {
+        df.unique_id: '{}{}'.format(root_url, df.filename)
+        for df in ensemble1_data_files
+    }
 
 
 def test_db_raster_configurator(mm_session):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -31,14 +31,20 @@ def test_db_raster_catalog(
     }
 
 
-@pytest.mark.parametrize('name, version, api_version, ensemble, root_url', [
-    ('A name', 'Version 0.0.0.1', '0.0', 'bc_prism', 'http://root.ca'),
+@pytest.mark.parametrize(
+    'name, version, api_version, ensemble, root_url, handlers',
+    [
+        ('A name', 'Version 0.0.0.1', '0.0', 'ensemble1', 'http://root.ca',
+         [
+             {'url': 'data_file_1', 'file': '/storage/data_file_1'},
+             {'url': 'data_file_2', 'file': '/storage/data_file_2'},
+         ]),
 ])
 def test_db_raster_configurator(
-    mm_test_session, name, version, api_version, ensemble, root_url
+    mm_test_session, name, version, api_version, ensemble, root_url, handlers,
 ):
     result = db_raster_configurator(
-        mm_test_session, name, version, api_version, ensemble, root_url
+        mm_test_session, name, version, api_version, ensemble, root_url,
     )
     assert all(
         x in result.items()
@@ -50,26 +56,6 @@ def test_db_raster_configurator(
             'api_version': api_version,
         }.items()
     )
-
-
-@pytest.mark.parametrize(
-    'name, version, api_version, ensemble, root_url, handlers',
-    [
-        ('A name', 'Version 0.0.0.1', '0.0', 'ensemble1', 'http://root.ca',
-         [
-             {'url': 'data_file_1', 'file': '/storage/data_file_1'},
-             {'url': 'data_file_2', 'file': '/storage/data_file_2'},
-         ]),
-])
-def test_db_raster_configurator_handlers(
-    mm_test_session, name, version, api_version, ensemble, root_url, handlers,
-):
-    # Handlers must be tested seperately because they are a list and order
-    # cannot be guaranteed on database query
-    result = db_raster_configurator(
-        mm_test_session, name, version, api_version, ensemble, root_url,
-    )
-    print('### handlers', result['handlers'])
     assert all(
         x in result['handlers']
         for x in handlers

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -81,7 +81,7 @@ def test_ensemble_catalog(
 # Valid request= types, variety of id, var cases.
 @pytest.mark.parametrize('req, keys', [
     ('GetMinMax', {'min', 'max'}),
-    # ('GetMinMaxWithUnits', {'min', 'max', 'units'}),
+    ('GetMinMaxWithUnits', {'min', 'max', 'units'}),
 ])
 @pytest.mark.parametrize('id_, var, status, content_type', [
     ('unique_id_0', 'var_0', '200 OK', 'application/json'),

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1,3 +1,4 @@
+from os.path import basename
 from pdp_util.raster import ensemble_files, db_raster_catalog, db_raster_configurator, EnsembleCatalog
 import json
 
@@ -25,7 +26,7 @@ def test_db_raster_catalog(
 ):
     result = db_raster_catalog(mm_test_session, ensemble1.name, root_url)
     assert result == {
-        df.unique_id: '{}{}'.format(root_url, df.filename)
+        df.unique_id: '{}{}'.format(root_url, basename(df.filename))
         for df in ensemble1_data_files
     }
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -30,14 +30,25 @@ def test_db_raster_catalog(
     }
 
 
-def test_db_raster_configurator(mm_session):
-    args = [mm_session, 'A name', 'Version 0.0.0.1', '0.0', 'bc_prism', 'http://basalt.pcic.uvic.ca:8080/data/']
-    result = db_raster_configurator(*args)
-    assert all([x in result.items() for x in {'root_url': 'http://basalt.pcic.uvic.ca:8080/data/',
-                                             'name': 'A name',
-                                             'version': 'Version 0.0.0.1',
-                                             'ensemble': 'bc_prism',
-                                             'api_version': '0.0'}.items()])
+@pytest.mark.parametrize('name, version, api_version, ensemble, root_url', [
+    ('A name', 'Version 0.0.0.1', '0.0', 'bc_prism', 'http://root.ca'),
+])
+def test_db_raster_configurator(
+    mm_test_session, name, version, api_version, ensemble, root_url
+):
+    result = db_raster_configurator(
+        mm_test_session, name, version, api_version, ensemble, root_url
+    )
+    assert all(
+        x in result.items()
+        for x in {
+            'root_url': root_url,
+            'name': name,
+            'version': version,
+            'ensemble': ensemble,
+            'api_version': api_version,
+        }.items()
+    )
 
 
 def test_db_raster_configurator_handlers(mm_session):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -112,7 +112,7 @@ def test_raster_metadata_minmax(
     id_, var, status
 ):
     qps = query_params((('request', req), ('id', id_), ('var', var)))
-    test_wsgi_app(raster_metadata, qps, status, keys)
+    test_wsgi_app(raster_metadata, qps, status, 'application/json', keys)
 
 
 # One final test that doesn't fit the parametrization pattern above.
@@ -125,4 +125,4 @@ def test_raster_metadata_minmax_no_id(
         ('id', 'unique_id_1'),
         ('var', 'var_1')
     ))
-    test_wsgi_app(raster_metadata, qps, '400 Bad Request', {})
+    test_wsgi_app(raster_metadata, qps, '400 Bad Request', None, None)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -8,11 +8,15 @@ from webob.request import Request
 def config():
     return {'ensemble': 'bc_prism', 'root_url': 'http://basalt.pcic.uvic.ca:8080/data/'}
 
-def test_ensemble_files(mm_session):
-    result = ensemble_files(mm_session, 'bc_prism')
-    assert result == {'tmax_monClim_PRISM_historical_run1_197101-200012': '/home/data/climate/PRISM/dataportal/tmax_monClim_PRISM_historical_run1_197101-200012.nc',
-                      'pr_monClim_PRISM_historical_run1_197101-200012': '/home/data/climate/PRISM/dataportal/pr_monClim_PRISM_historical_run1_197101-200012.nc',
-                      'tmin_monClim_PRISM_historical_run1_197101-200012': '/home/data/climate/PRISM/dataportal/tmin_monClim_PRISM_historical_run1_197101-200012.nc'}
+
+def test_ensemble1_files(mm_test_session, ensemble1, ensemble1_data_files):
+    result = ensemble_files(mm_test_session, ensemble1.name)
+    assert result == {df.unique_id: df.filename for df in ensemble1_data_files}
+
+
+def test_ensemble2_files(mm_test_session, ensemble2, ensemble2_data_files):
+    result = ensemble_files(mm_test_session, ensemble2.name)
+    assert result == {df.unique_id: df.filename for df in ensemble2_data_files}
 
 
 def test_db_raster_catalog(mm_session, config):
@@ -20,7 +24,8 @@ def test_db_raster_catalog(mm_session, config):
     assert result == {'tmax_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/tmax_monClim_PRISM_historical_run1_197101-200012.nc',
                       'pr_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/pr_monClim_PRISM_historical_run1_197101-200012.nc',
                       'tmin_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/tmin_monClim_PRISM_historical_run1_197101-200012.nc'}
-    
+
+
 def test_db_raster_configurator(mm_session):
     args = [mm_session, 'A name', 'Version 0.0.0.1', '0.0', 'bc_prism', 'http://basalt.pcic.uvic.ca:8080/data/']
     result = db_raster_configurator(*args)
@@ -29,6 +34,7 @@ def test_db_raster_configurator(mm_session):
                                              'version': 'Version 0.0.0.1',
                                              'ensemble': 'bc_prism',
                                              'api_version': '0.0'}.items()])
+
 
 def test_db_raster_configurator_handlers(mm_session):
     # Handlers must be tested seperately because they are a list and order cannot be guaranteed on database query
@@ -42,6 +48,7 @@ def test_db_raster_configurator_handlers(mm_session):
     result = db_raster_configurator(*args)
     assert all([x in result['handlers'] for x in handlers])
 
+
 @pytest.mark.parametrize('url', ['', '/url/is/irrellevant'])
 def test_ensemble_catalog(mm_dsn, config, url):
     app = EnsembleCatalog(mm_dsn, config)
@@ -54,6 +61,7 @@ def test_ensemble_catalog(mm_dsn, config, url):
                     'pr_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/pr_monClim_PRISM_historical_run1_197101-200012.nc',
                     'tmin_monClim_PRISM_historical_run1_197101-200012': 'http://basalt.pcic.uvic.ca:8080/data/tmin_monClim_PRISM_historical_run1_197101-200012.nc'}
 
+
 def test_raster_metadata_minmax(raster_metadata):
     req = Request.blank('?request=GetMinMax&id=pr-tasmax-tasmin_day_BCSD-ANUSPLIN300-CanESM2_historical-rcp26_r1i1p1_19500101-21001231&var=tasmax')
     resp = req.get_response(raster_metadata)
@@ -64,6 +72,7 @@ def test_raster_metadata_minmax(raster_metadata):
     stats = json.loads(resp.body)
     assert len(stats) == 2
     assert set(stats.keys()) == set(['max', 'min'])
+
 
 def test_raster_metadata_minmax_w_units(raster_metadata):
     req = Request.blank('?request=GetMinMaxWithUnits&id=pr-tasmax-tasmin_day_BCSD-ANUSPLIN300-CanESM2_historical-rcp26_r1i1p1_19500101-21001231&var=tasmax')
@@ -76,20 +85,24 @@ def test_raster_metadata_minmax_w_units(raster_metadata):
     assert len(stats) == 3
     assert set(stats.keys()) == set(['max', 'min', 'units'])
 
+
 def test_raster_metadata_minmax_no_id(raster_metadata):
     req = Request.blank('?request=INVALID_REQUEST_TYPE&id=pr-tasmax-tasmin_day_BCSD-ANUSPLIN300-CanESM2_historical-rcp26_r1i1p1_19500101-21001231&var=tasmax')
     resp = req.get_response(raster_metadata)
     assert resp.status == '400 Bad Request'
+
 
 def test_raster_metadata_minmax_no_id(raster_metadata):
     req = Request.blank('?request=GetMinMax&var=tasmax')
     resp = req.get_response(raster_metadata)
     assert resp.status == '400 Bad Request'
 
+
 def test_raster_metadata_minmax_no_var(raster_metadata):
     req = Request.blank('?request=GetMinMax&id=pr-tasmax-tasmin_day_BCSD-ANUSPLIN300-CanESM2_historical-rcp26_r1i1p1_19500101-21001231')
     resp = req.get_response(raster_metadata)
     assert resp.status == '400 Bad Request'
+
 
 def test_raster_metadata_minmax_bad_id(raster_metadata):
     req = Request.blank('?request=GetMinMax&id=NOT_A_VALID_ID&var=tasmax')


### PR DESCRIPTION
Resolves #15 

As noted in the issue above, the change to the code that queries the database is trivial. 

Adjusting the corresponding tests was more work, and is the bulk of this PR. Specifically, now all modelmeta test database setup is (a) within `pdp_util`, (b) done in test code, and (c) responsible for by far the largest number of lines of new code (in `conftest.py`). A lot of redundancy was DRYed up and some dead code was removed from the tests. 