### PR TITLE
Add filepath to /metadata response

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,25 @@
+name: Docker Publishing
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+
+jobs:
+  publish-local-pytest:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish to Registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.pcicdevops_at_dockerhub_username }}
+          password: ${{ secrets.pcicdevops_at_dockerhub_password }}
+          dockerfile: ./docker/local-pytest/Dockerfile
+          repository: pcic/pdp_util-local-pytest
+          tag_with_ref: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
-        sudo apt-get install postgresql-10-postgis-2.3 postgresql-10-postgis-scripts
+        sudo apt-get install libhdf5-serial-dev libnetcdf-dev libspatialite-dev postgresql-9.5-postgis-2.4
         pip install -r requirements.txt -r test_requirements.txt
         pip install .
     - name: Test with pytest (full)

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,17 @@ Globally applicable utilities
 * The `auth` module contains WSGI middleware for providing authentication via OpenID.
 * The `dbdict` module contains a function to convert dict object into a database DSN.
 
+Testing
+-------
+
+Our production database environment (PostgreSQL 9.1) is far out of date and it is hard to establish a
+local installation suitable for running tests. But it is reasonably easy to build Docker images containing
+the desired environment for testing. This is done in two ways:
+
+* In the python-ci GitHub action, which performs automated testing on every push.
+* In the Docker image `pcic/pdp_util-local-pytest`, which can be run locally in interactive mode to provide
+  a persistent environment for running tests. For details, its [README](docker/local-pytest/README.md).
+
 
 .. rubric:: Footnotes
 

--- a/docker/local-pytest/Dockerfile
+++ b/docker/local-pytest/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+# Get set to install packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+
+# Set the locale
+RUN apt-get -y install locales && \
+    locale-gen en_CA.utf8
+ENV LANG en_CA.utf8
+ENV LANGUAGE en_CA:en
+ENV LC_ALL en_CA.UTF-8
+
+# Make legacy Ubuntu 18.04 postgres-9.5 packages available
+RUN apt-get install -y curl ca-certificates gnupg && \
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    echo 'deb http://apt.postgresql.org/pub/repos/apt bionic-pgdg main' >/etc/apt/sources.list.d/pgdg.list && \
+    apt-get update
+
+# Install the packages required to install PyCDS.
+RUN apt-get install -yq \
+            libpq-dev \
+            python2.7 \
+            python2.7-dev \
+            python-pip \
+            postgresql-plpython-9.5 \
+            postgresql-9.5-postgis-2.4 \
+    && echo "done"
+RUN pip install -U pip pytest
+
+# You must mount local codebase to this directory
+WORKDIR /codebase
+
+# Install the local codebase when the container starts.
+ENTRYPOINT ./docker/local-test/entrypoint.sh

--- a/docker/local-pytest/Dockerfile
+++ b/docker/local-pytest/Dockerfile
@@ -32,4 +32,4 @@ RUN pip install -U pip pytest
 WORKDIR /codebase
 
 # Install the local codebase when the container starts.
-ENTRYPOINT ./docker/local-test/entrypoint.sh
+ENTRYPOINT ./docker/local-pytest/entrypoint.sh

--- a/docker/local-pytest/Dockerfile
+++ b/docker/local-pytest/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get install -yq \
             python-pip \
             postgresql-plpython-9.5 \
             postgresql-9.5-postgis-2.4 \
-    && echo "done"
-RUN pip install -U pip pytest
+            && \
+    pip install -U pip pytest
 
 # You must mount local codebase to this directory
 WORKDIR /codebase

--- a/docker/local-pytest/README.md
+++ b/docker/local-pytest/README.md
@@ -1,0 +1,121 @@
+# Docker image for local test environment
+
+## What
+
+The files in this directory allow you to build and run a test environment
+for PyCDS equivalent to that in the GitHub Actions CI. Within this environment
+you can run part or all of the test suite, or do other dev/debug activities.
+
+## Why
+
+1. We are currently running CI tests in a very antiquated environment which 
+is difficult if not impossible to reproduce on an up-to-date dev machine. 
+Plus it messes up your machine. Docker containers to the rescue.
+
+1. We could just let the CI do the work, but it can take from 2 to 5 minutes
+to run a single test ... most of that consumed by setting up the docker 
+container for the test run.
+
+1. So let's just build that environment once, run it interactively, 
+run our tests from inside there, and wow zippy. Debugging now feasible.
+
+## How
+
+1. The image is built with all the contents necessary to install and run PyCDS
+and its tests. 
+
+1. But since we want to run our own, local test code, we can't install PyCDS 
+from a repo. Instead we install from our local codebase when the container is 
+started.
+
+1. To facilitate this, we set up a working diretory (WORKDIR) in the image
+called `/codebase`. 
+
+1. When we run the image, we must mount our local codebase to `/codebase`.
+(See Run image).
+
+1. When the container starts (image runs), the script 
+`entrypoint.sh` installs the local version of PyCDS (in development mode `-e`). 
+It also sets up 
+and `su`s a non-root user, `test`, because PostgreSQL refuses -- sensibly --
+to run as the root user, which is what we are up to this point.
+
+1. Because we have mounted our codebase to the
+container, when we make changes to it (outside the container), those changes
+are available inside the container, and vice-versa. Therefore we can use all
+our local tools outside the container as normal (which is a shedload easier
+than trying to install your IDE inside the container :) ).
+
+1. The vice-versa has a downside, which is that runs of the tests leave
+behind a set "orphaned" pytest caches which will cause the next
+run of the image to fail if they are not cleaned up first with `py3clean`.
+We don't, however mount the codebase read-only because we might want 
+some effects of the test runs to be written to our external filesystem 
+(e.g., redirected output).
+
+## Notes and caveats
+
+1. Writing to a mounted volume from inside a docker container involves some
+tricky permissions logic that I don't fully understand yet. Known:
+    - If the user inside the container has the same user id 
+    (numeric, e.g., 1000) as the owner of the mounted file or directory outside 
+    the container, then it is possible to write to the mounted volume 
+    (e.g., to redirect output from a test run to a file). 
+    - If the user id's differ, a permissions error is raised and the write 
+    fails.
+    - Default user id (of the first user) on a Linux system is 1000.
+    My own user id (rglover) is 1000. Hence the setting of user id 1000
+    in `entrypoint.sh`. If your user id is not 1000, you will need to change
+    this if you wish to write content from inside the container.
+    - This is a hack and should be cleaned up so it works
+    generally. That will require some research into Docker's mechanisms for
+    mapping user ids between a container and its run environment, not for the
+    fainthearted. 
+
+1. As noted above, running tests in the test container in read/write mode 
+leaves problematic pycache junk behind in the host filesystem. 
+This can be cleaned up by running `py3clean`.
+
+## Pull image
+
+The GitHub Action docker-publish automatically builds the image.
+Pull it from Dockerhub:
+
+```
+docker pull pcic/pdp_util-local-pytest
+```
+
+## Run image (container)
+
+Run it from the project root directory:
+
+```
+pyclean .
+docker run -it -v $(pwd):/codebase pcic/pdp_util-local-pytest
+```
+
+When the container starts, it installs the local codebase as described above.
+After that, you are in interactive mode, in a bash shell, so you can issue 
+commands, such as `py.test ....` as normal.
+
+Leave the container running for as long as you want. You can do multiple
+rounds of modification and testing using a single container, without
+restarting (which was the justification for creating it).
+
+## Build image (manual)
+
+Since this image is built automatically by the GitHub Action docker-publish,
+you should not need to do this. However, just in case:
+
+From the _project root directory_ (important Docker context location):
+
+```
+docker build -t pcic/pdp_util-local-pytest -f docker/local-test/Dockerfile .
+```
+
+If you are having trouble installing packages that should be there, try using
+the `--no-cache` build option:
+
+```
+docker build --no-cache -t pcic/pdp_util-local-pytest -f docker/local-test/Dockerfile .
+```

--- a/docker/local-pytest/README.md
+++ b/docker/local-pytest/README.md
@@ -3,7 +3,7 @@
 ## What
 
 The files in this directory allow you to build and run a test environment
-for PyCDS equivalent to that in the GitHub Actions CI. Within this environment
+for `pdp_util` equivalent to that in the GitHub Actions CI. Within this environment
 you can run part or all of the test suite, or do other dev/debug activities.
 
 ## Why
@@ -21,10 +21,10 @@ run our tests from inside there, and wow zippy. Debugging now feasible.
 
 ## How
 
-1. The image is built with all the contents necessary to install and run PyCDS
+1. The image is built with all the contents necessary to install and run `pdp_util`
 and its tests. 
 
-1. But since we want to run our own, local test code, we can't install PyCDS 
+1. But since we want to run our own, local test code, we can't install `pdp_util` 
 from a repo. Instead we install from our local codebase when the container is 
 started.
 
@@ -35,7 +35,7 @@ called `/codebase`.
 (See Run image).
 
 1. When the container starts (image runs), the script 
-`entrypoint.sh` installs the local version of PyCDS (in development mode `-e`). 
+`entrypoint.sh` installs the local version of `pdp_util` (in development mode `-e`). 
 It also sets up 
 and `su`s a non-root user, `test`, because PostgreSQL refuses -- sensibly --
 to run as the root user, which is what we are up to this point.

--- a/docker/local-pytest/entrypoint.sh
+++ b/docker/local-pytest/entrypoint.sh
@@ -1,6 +1,6 @@
 # Install PyCDS
-pip3 install -r requirements.txt -r test_requirements.txt
-pip3 install -e .
+pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt -r test_requirements.txt
+pip install -e .
 
 # Use a non-root user so that Postgres doesn't object
 # Important: See README for reason user id 1000 is set here.

--- a/docker/local-pytest/entrypoint.sh
+++ b/docker/local-pytest/entrypoint.sh
@@ -1,0 +1,9 @@
+# Install PyCDS
+pip3 install -r requirements.txt -r test_requirements.txt
+pip3 install -e .
+
+# Use a non-root user so that Postgres doesn't object
+# Important: See README for reason user id 1000 is set here.
+useradd -u 1000 test
+chsh -s /bin/bash test
+su test

--- a/pdp_util/raster.py
+++ b/pdp_util/raster.py
@@ -145,11 +145,11 @@ class RasterMetadata(object):
 
         # Content specified by 'include' query param
         try:
-            include_items = req.params["include"].split(',')
+            include_items = set(req.params["include"].split(','))
             if not (include_items <= {"filepath", "units"}):
                 start_response('400 Bad Request', [])
                 return ["Invalid value(s) in 'include' parameter"]
-            content_items |= set(include_items)
+            content_items |= include_items
         except KeyError:
             pass
 

--- a/pdp_util/raster.py
+++ b/pdp_util/raster.py
@@ -1,6 +1,7 @@
 import os
 from os.path import basename
 
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from pydap.wsgi.app import DapServer
 from pdp_util import session_scope
 from modelmeta import DataFile, DataFileVariableDSGTimeSeries, EnsembleDataFileVariables, Ensemble, VariableAlias
@@ -120,115 +121,92 @@ class RasterMetadata(object):
         self.session_scope_factory = session_scope_factory
 
     def __call__(self, environ, start_response):
+        """Handle requests for metadata"""
+
         req = Request(environ)
+
+        # Get and validate required parameters
         try:
-            request_type = req.params['request']
+            unique_id = req.params['id']
+        except:
+            start_response('400 Bad Request', [])
+            return ["Required parameter 'id' not specified"]
+
+        try:
+            var = req.params['var']
+        except:
+            start_response('400 Bad Request', [])
+            return ["Required parameter 'var' not specified"]
+
+        # Establish content of response
+
+        # Default content
+        content_items = {"min", "max"}
+
+        # Content specified by 'include' query param
+        try:
+            include_items = req.params["include"].split(',')
+            if not (include_items <= {"filepath", "units"}):
+                start_response('400 Bad Request', [])
+                return ["Invalid values for 'include' parameter"]
+            content_items |= set(include_items)
         except KeyError:
-            start_response('400 Bad Request', [])
-            return ["Required parameter 'request' not specified"]
+            pass
 
-        if request_type == 'GetMinMax':
-            return self.getMinMax(environ, start_response, req)
-        elif request_type == 'GetMinMaxWithUnits':
-            return self.getMinMaxWithUnits(environ, start_response, req)
-
-        start_response('400 Bad Request', [])
-        return ["Request type not valid"]
-
-    def getMinMax(self, environ, start_response, req):
-        '''
-        Fuction to handle min/max requests to the MDDB.
-
-        Requires `id` and `var` as url parameters and returns a json object
-        with min/max keys.
-        Returns 400 if `id` or `var` not specified,
-        or 404 if id/var combo not found in the MDDB
-
-        :param req: Request object containing parsed url parameters
-        :type req: webob.request.Request
-        '''
+        # Content specified by 'request' query param
         try:
-            unique_id = req.params['id']
-        except:
-            start_response('400 Bad Request', [])
-            return ["Required parameter 'id' not specified"]
+            request_qp = req.params["request"]
+            if request_qp == "GetMinMaxWithUnits":
+                content_items |= {"units"}
+        except KeyError:
+            pass
 
-        try:
-            var = req.params['var']
-        except:
-            start_response('400 Bad Request', [])
-            return ["Required parameter 'var' not specified"]
+        # Build query according to content of response
+
+        # Default content
+        columns = (
+            DataFileVariableDSGTimeSeries.range_min.label("min"),
+            DataFileVariableDSGTimeSeries.range_max.label("max"),
+        )
+        joins = (DataFile,)
+
+        # 'filepath' content
+        if "filepath" in content_items:
+            columns += (DataFile.filename.label("filepath"),)
+
+        # 'units' content
+        if "units" in content_items:
+            columns += (VariableAlias.units.label("units"),)
+            joins += (VariableAlias,)
 
         with self.session_scope_factory() as sesh:
-            r = sesh.query(DataFileVariableDSGTimeSeries.range_min, DataFileVariableDSGTimeSeries.range_max)\
-                .join(DataFile)\
-                .filter(DataFile.unique_id == unique_id)\
+            q = (
+                sesh.query(*columns)
+                .filter(DataFile.unique_id == unique_id)
                 .filter(DataFileVariableDSGTimeSeries.netcdf_variable_name == var)
-
-        if r.count() == 0: # Result does not contain any row therefore id/var combo does not exist
-            return response_404(
-                start_response,
-                "Unable to find requested id/var combo"
             )
+            for Table in joins:
+                q = q.join(Table)
 
-        if r.count() > 1: # Result has multiple rows, panic
-            return response_404(
-                start_response,
-                "Multiple matching id/var combos. This should not happen."
-            )
-
-        mn, mx = r.first()
-        d = {'min': mn, 'max': mx }
-
-        return response_200(start_response, d)
-
-    def getMinMaxWithUnits(self, environ, start_response, req):
-        '''
-        Fuction to handle min/max requests to the MDDB.
-
-        Requires `id` and `var` as url parameters and returns a json object
-        with min/max keys.
-        Returns 400 if `id` or `var` not specified,
-        or 404 if id/var combo not found in the MDDB
-
-        :param req: Request object containing parsed url parameters
-        :type req: webob.request.Request
-        '''
+        # Execute query
         try:
-            unique_id = req.params['id']
-        except:
-            start_response('400 Bad Request', [])
-            return ["Required parameter 'id' not specified"]
-
-        try:
-            var = req.params['var']
-        except:
-            start_response('400 Bad Request', [])
-            return ["Required parameter 'var' not specified"]
-
-        with self.session_scope_factory() as sesh:
-            r = sesh.query(DataFileVariableDSGTimeSeries.range_min, DataFileVariableDSGTimeSeries.range_max, VariableAlias.units)\
-                .join(DataFile)\
-                .join(VariableAlias)\
-                .filter(DataFile.unique_id == unique_id)\
-                .filter(DataFileVariableDSGTimeSeries.netcdf_variable_name == var)
-
-        if r.count() == 0: # Result does not contain any row therefore id/var combo does not exist
+            result = q.one()
+        except NoResultFound:
             return response_404(
                 start_response,
-                "Unable to find requested id/var combo"
+                "Unable to find specified combination of id and var"
             )
-
-        if r.count() > 1: # Result has multiple rows, panic
+        except MultipleResultsFound:
             return response_404(
                 start_response,
-                "Multiple matching id/var combos. This should not happen."
+                "Multiple matches to specified id and var combination. "
+                "This should not happen."
             )
 
-        mn, mx, units = r.first()
-        d = {'min': mn, 'max': mx , 'units': units}
+        # Build and return response
+        content = {key: getattr(result, key) for key in content_items}
+        return response_200(start_response, content)
 
-        return response_200(start_response, d)
 
 def db_raster_catalog(session, ensemble, root_url):
     '''A function which queries the database for all of the raster files belonging to a given ensemble. Returns a dict where keys are the dataset unique ids and the value is the filename for the dataset.

--- a/pdp_util/raster.py
+++ b/pdp_util/raster.py
@@ -148,7 +148,7 @@ class RasterMetadata(object):
             include_items = req.params["include"].split(',')
             if not (include_items <= {"filepath", "units"}):
                 start_response('400 Bad Request', [])
-                return ["Invalid values for 'include' parameter"]
+                return ["Invalid value(s) in 'include' parameter"]
             content_items |= set(include_items)
         except KeyError:
             pass
@@ -156,6 +156,9 @@ class RasterMetadata(object):
         # Content specified by 'request' query param
         try:
             request_qp = req.params["request"]
+            if request_qp not in {"GetMinMax", "GetMinMaxWithUnits"}:
+                start_response('400 Bad Request', [])
+                return ["Invalid value for 'request' parameter"]
             if request_qp == "GetMinMaxWithUnits":
                 content_items |= {"units"}
         except KeyError:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -129,6 +129,7 @@ def test_raster_metadata_minmax(
 @pytest.mark.parametrize('req, include', [
     ('invalid', None),
     (None, 'invalid'),
+    (None, 'units,invalid'),
     ('invalid', 'invalid'),
 ])
 @pytest.mark.usefixtures('mm_test_session_committed')
@@ -139,6 +140,6 @@ def test_raster_metadata_minmax_bad_params(
         ('request', req),
         ('include', include),
         ('id', 'unique_id_1'),
-        ('var', 'var_1')
+        ('var', 'var_2')
     )
     test_wsgi_app(raster_metadata, url, '400 Bad Request', None)


### PR DESCRIPTION
Resolves #22 . Also fixes python-ci test environment.

This PR changes the `/metadata` endpoint in the following ways:

- make the default response, regardless of query parameters, contain `min` and `max`
- add an optional query parameter `include` with the following valid values, specified as a comma-separated list:
  - `units`
  - `filepath`
- make `request` an optional query parameter with the following meanings:
  - `request=GetMinMax`: default response
  - `request=GetMinMaxWithUnits`: include `units` in response

An example request to this revised API is `/metadata.json?include=filepath,units`.

This change supersedes ("deprecates" is too strong a word) the previous API definition, by effectively replacing the `request` parameter with the `include` parameter. However, the old `request=` style still functions as it did to ensure backward compatibility.

This PR also adds the infrastructure for building a Docker image containing an appropriate test environment for this package. It has been exercised and works as advertised. It is a minor variation of the infrastructure established for the same purpose in PyCDS.