### PR TITLE
Handle empty station list in `get_all_metadata_index_responders()`

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,7 @@ jobs:
       env:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
+        sudo apt purge postgresql-client-13 postgresql-server-dev-13
         sudo apt-get install libhdf5-serial-dev libnetcdf-dev libspatialite-dev postgresql-9.5-postgis-2.4
         pip install -r requirements.txt -r test_requirements.txt
         pip install .

--- a/docker/local-pytest/README.md
+++ b/docker/local-pytest/README.md
@@ -110,7 +110,7 @@ you should not need to do this. However, just in case:
 From the _project root directory_ (important Docker context location):
 
 ```
-docker build -t pcic/pdp_util-local-pytest -f docker/local-test/Dockerfile .
+docker build -t pcic/pdp_util-local-pytest -f docker/local-pytest/Dockerfile .
 ```
 
 If you are having trouble installing packages that should be there, try using

--- a/pdp_util/agg.py
+++ b/pdp_util/agg.py
@@ -91,10 +91,10 @@ def get_all_metadata_index_responders(sesh, stations, climo=False):
     :type climo: bool
     :rtype: iterator
     '''
-    nets = set(zip(*stations)[0])
-    for net in nets:
-        filename = '{0}/variables.csv'.format(net)
-        yield (filename, metadata_index_responder(sesh, net, climo))
+    for station in stations:
+        network_name = station[0]
+        filename = '{0}/variables.csv'.format(network_name)
+        yield (filename, metadata_index_responder(sesh, network_name, climo))
 
 def metadata_index_responder(sesh, network, climo=False):
     '''The function creates a pydap csv response which lists variable metadata out of the database. It returns an generator for the contents of the file

--- a/tests/test_agg.py
+++ b/tests/test_agg.py
@@ -31,18 +31,36 @@ def test_metadata_index_responder(test_session):
     for line in lines:
         assert line in response_text
 
-# This seems dumb to test, but it's cheap
-def test_get_all_metadata_index_responders(test_session, monkeypatch):
+
+@pytest.mark.parametrize(
+    "stations, expected_filenames",
+    [
+        ([], set()),
+        (
+            stns,
+            set([
+                'ARDA/variables.csv',
+                'EC_raw/variables.csv',
+                'FLNRO-WMB/variables.csv'
+            ])
+        ),
+    ]
+)
+def test_get_all_metadata_index_responders(
+    test_session,
+    monkeypatch,
+    stations,
+    expected_filenames,
+):
     # Content is tested elsewhere. Fake it out.
     def fake_metadata_index_responder(sesh, net, climo):
         return []
     monkeypatch.setattr(pdp_util.agg, 'metadata_index_responder', fake_metadata_index_responder)
 
-    expected_filenames = set(['ARDA/variables.csv', 'EC_raw/variables.csv', 'FLNRO-WMB/variables.csv'])
-
-    resp = get_all_metadata_index_responders(test_session, stns, False)
+    resp = get_all_metadata_index_responders(test_session, stations, False)
     filenames = set([filename for filename, content in resp])
     assert filenames == expected_filenames
+
 
 def test_get_pcds_responders(conn_params, monkeypatch):
     # Don't care about content (tested elsewhere); just return the environ


### PR DESCRIPTION
Resolves #8 

This PR does not address the reason *why* the station list is empty. The superficial answer is because the station filters are filtering out all stations, yielding an empty list. Whether that is possible or legitimate is a question without an answer at the moment, although it does not seem a priori erroneous.