### PR TITLE
(Py2) Fix DFV queries

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,10 @@ jobs:
       env:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
+        sudo apt-get install -y curl ca-certificates gnupg
+        sudo curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo echo 'deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main' | sudo tee /etc/apt/sources.list.d/pgdg.list
+        sudo apt-get update
         sudo apt purge postgresql-client-13 postgresql-server-dev-all
         sudo apt-get install libhdf5-serial-dev libnetcdf-dev libspatialite-dev postgresql-12-postgis-3
         pip install -r requirements.txt -r test_requirements.txt

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # News / Release Notes
 
+## 1.2.1
+
+*Release Date: 2021-Jun-14*
+
+Release for integration test with `pdp`. 
+
+- Fixes DataFileVariable queries for modelmeta >=0.3.0
+- Fixes Python CI build
+
+
 ## 1.2.0
 
 *Release Date: 2021-May-27*

--- a/pdp_util/raster.py
+++ b/pdp_util/raster.py
@@ -6,7 +6,7 @@ from pydap.wsgi.app import DapServer
 from pdp_util import session_scope
 from modelmeta import (
     DataFile,
-    DataFileVariableDSGTimeSeries,
+    DataFileVariableGridded,
     EnsembleDataFileVariables,
     Ensemble,
     VariableAlias,
@@ -191,8 +191,8 @@ class RasterMetadata(object):
 
         # Default content
         columns = (
-            DataFileVariableDSGTimeSeries.range_min.label("min"),
-            DataFileVariableDSGTimeSeries.range_max.label("max"),
+            DataFileVariableGridded.range_min.label("min"),
+            DataFileVariableGridded.range_max.label("max"),
         )
         joins = (DataFile,)
 
@@ -209,7 +209,7 @@ class RasterMetadata(object):
             q = (
                 sesh.query(*columns)
                 .filter(DataFile.unique_id == unique_id)
-                .filter(DataFileVariableDSGTimeSeries.netcdf_variable_name == var)
+                .filter(DataFileVariableGridded.netcdf_variable_name == var)
             )
             for Table in joins:
                 q = q.join(Table)
@@ -276,7 +276,7 @@ def db_raster_configurator(session, name, version, api_version, ensemble, root_u
 def ensemble_files(session, ensemble_name):
     q = (
         session.query(DataFile)
-        .join(DataFileVariableDSGTimeSeries)
+        .join(DataFileVariableGridded)
         .join(EnsembleDataFileVariables)
         .join(Ensemble)
         .filter(Ensemble.name == ensemble_name)

--- a/setup.py
+++ b/setup.py
@@ -3,57 +3,58 @@ import string
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
+
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = ['-v', '--tb=short' ,'--pdb', 'tests']
+        self.test_args = ["-v", "--tb=short", "--pdb", "tests"]
         self.test_suite = True
+
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import pytest
+
         errno = pytest.main(self.test_args)
-        sys.exit(errno)                                                                        
+        sys.exit(errno)
+
 
 __version__ = (1, 2, 0)
 
 setup(
     name="pdp_util",
-    package_dir = {'pdp_util': 'pdp_util'},
+    package_dir={"pdp_util": "pdp_util"},
     description="A package supplying numerous apps for running PCIC's data server",
     keywords="sql database opendap dods dap data science climate oceanography meteorology",
-    packages=['pdp_util'],
-    version='.'.join(str(d) for d in __version__),
+    packages=["pdp_util"],
+    version=".".join(str(d) for d in __version__),
     url="http://www.pacificclimate.org/",
     author="James Hiebert",
     author_email="hiebert@uvic.ca",
-    install_requires=['webob',
-                      'openid2rp',
-                      'genshi',
-                      'paste',
-                      'beaker',
-                      'pillow',
-                      'pytz',
-                      'simplejson',
-                      'pycds >=0.0.20',
-                      'numpy',
-                      'python-dateutil',
-                      # raster portal stuff
-                      'pydap_pdp >=3.2.1',
-                      'pydap.handlers.pcic >=0.0.3',
-                      'modelmeta >=0.3.0',
-                      'PyYAML'
-                      ],
-    tests_require=['pytest',
-                   'sqlalchemy',
-                   'beautifulsoup4'
-                  ],
-    cmdclass = {'test': PyTest},
+    install_requires=[
+        "webob",
+        "openid2rp",
+        "genshi",
+        "paste",
+        "beaker",
+        "pillow",
+        "pytz",
+        "simplejson",
+        "pycds >=0.0.20",
+        "numpy",
+        "python-dateutil",
+        # raster portal stuff
+        "pydap_pdp >=3.2.1",
+        "pydap.handlers.pcic >=0.0.3",
+        "modelmeta >=0.3.0",
+        "PyYAML",
+    ],
+    tests_require=["pytest", "sqlalchemy", "beautifulsoup4"],
+    cmdclass={"test": PyTest},
     zip_safe=True,
-    package_data={'pdp_util': ['data/alpha.png',
-                               'data/*.css',
-                               'templates/*.html']},
-
-        classifiers='''Development Status :: 5 - Production/Stable
+    package_data={
+        "pdp_util": ["data/alpha.png", "data/*.css", "templates/*.html"]
+    },
+    classifiers="""Development Status :: 5 - Production/Stable
 Environment :: Console
 Environment :: Web Environment
 Intended Audience :: Developers
@@ -64,5 +65,7 @@ Programming Language :: Python :: 2.7
 Topic :: Internet
 Topic :: Internet :: WWW/HTTP :: WSGI
 Topic :: Scientific/Engineering
-Topic :: Software Development :: Libraries :: Python Modules'''.split('\n')
+Topic :: Software Development :: Libraries :: Python Modules""".split(
+        "\n"
+    ),
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-__version__ = (1, 2, 0)
+__version__ = (1, 2, 1)
 
 setup(
     name="pdp_util",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,9 @@ from modelmeta import (
     Model,
     Emission,
     Run,
+    Grid,
     DataFile,
-    DataFileVariableDSGTimeSeries,
+    DataFileVariableGridded,
     VariableAlias,
     Ensemble,
 )
@@ -218,8 +219,23 @@ def make_variable_alias(i):
     )
 
 
-def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
-    return DataFileVariableDSGTimeSeries(
+def make_grid(i):
+    return Grid(
+        name="Grid {}".format(i),
+        evenly_spaced_y=True,
+        xc_count=99,
+        xc_grid_step=99,
+        xc_origin=99,
+        xc_units="furlong",
+        yc_count=99,
+        yc_grid_step=99,
+        yc_origin=99,
+        yc_units="furlong",
+    )
+
+
+def make_dfv_gridded(i, file=None, variable_alias=None, grid=None):
+    return DataFileVariableGridded(
         derivation_method="derivation_method_{}".format(i),
         variable_cell_methods="variable_cell_methods_{}".format(i),
         netcdf_variable_name="var_{}".format(i),
@@ -228,6 +244,7 @@ def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
         range_max=100,
         file=file,
         variable_alias=variable_alias,
+        grid=grid,
     )
 
 
@@ -298,14 +315,19 @@ def variable_aliases():
 
 
 @pytest.fixture(scope="function")
-def dfv_dsg_tss(data_files, variable_aliases):
+def grids():
+    return make(make_grid, 1)
+
+
+@pytest.fixture(scope="function")
+def dfv_dsg_tss(data_files, variable_aliases, grids):
     return make(
-        make_dfv_dsg_time_series,
+        make_dfv_gridded,
         [
-            (data_files[0], variable_aliases[0]),  # var 0, uid 0
-            (data_files[0], variable_aliases[1]),  # var 1, uid 0
-            (data_files[1], variable_aliases[1]),  # var 2, uid 1
-            (data_files[2], variable_aliases[1]),  # var 3, uid 2
+            (data_files[0], variable_aliases[0], grids[0]),  # var 0, uid 0
+            (data_files[0], variable_aliases[1], grids[0]),  # var 1, uid 0
+            (data_files[1], variable_aliases[1], grids[0]),  # var 2, uid 1
+            (data_files[2], variable_aliases[1], grids[0]),  # var 3, uid 2
         ],
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,13 +321,14 @@ def grids():
 
 @pytest.fixture(scope="function")
 def dfv_dsg_tss(data_files, variable_aliases, grids):
+    grid = grids[0]
     return make(
         make_dfv_gridded,
         [
-            (data_files[0], variable_aliases[0], grids[0]),  # var 0, uid 0
-            (data_files[0], variable_aliases[1], grids[0]),  # var 1, uid 0
-            (data_files[1], variable_aliases[1], grids[0]),  # var 2, uid 1
-            (data_files[2], variable_aliases[1], grids[0]),  # var 3, uid 2
+            (data_files[0], variable_aliases[0], grid),  # var 0, uid 0
+            (data_files[0], variable_aliases[1], grid),  # var 1, uid 0
+            (data_files[1], variable_aliases[1], grid),  # var 2, uid 1
+            (data_files[2], variable_aliases[1], grid),  # var 3, uid 2
         ],
     )
 


### PR DESCRIPTION
This PR fixes incorrect `DataFileVariable` queries (for `modelmeta` >= 0.3.0, which is now our target version).

Note that this PR merges to branch `py2`.

This PR includes the following items:
- Fix for queries
- Fix for broken (bit rot) Python CI build
- Bump to version 1.2.1. A bit premature, but that was the best way to get a test build of PDP working. 