### PR TITLE
Update to modelmeta version 0.3.0

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,8 +21,8 @@ jobs:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
         sudo apt-get install -y curl ca-certificates gnupg
-	sudo curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-	sudo echo 'deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main' | sudo tee /etc/apt/sources.list.d/pgdg.list
+        sudo curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo echo 'deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main' | sudo tee /etc/apt/sources.list.d/pgdg.list
         sudo apt-get update
         sudo apt purge postgresql-client-13 postgresql-server-dev-all
         sudo apt-get install libhdf5-serial-dev libnetcdf-dev libspatialite-dev postgresql-12-postgis-3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,6 +20,10 @@ jobs:
       env:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
+        sudo apt-get install -y curl ca-certificates gnupg
+	sudo curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+	sudo echo 'deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main' | sudo tee /etc/apt/sources.list.d/pgdg.list
+        sudo apt-get update
         sudo apt purge postgresql-client-13 postgresql-server-dev-all
         sudo apt-get install libhdf5-serial-dev libnetcdf-dev libspatialite-dev postgresql-12-postgis-3
         pip install -r requirements.txt -r test_requirements.txt

--- a/pdp_util/raster.py
+++ b/pdp_util/raster.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from pdp_util import session_scope
 from modelmeta import (
     DataFile,
-    DataFileVariableDSGTimeSeries,
+    DataFileVariableGridded,
     EnsembleDataFileVariables,
     Ensemble,
     VariableAlias,
@@ -196,8 +196,8 @@ class RasterMetadata(object):
 
         # Default content
         columns = (
-            DataFileVariableDSGTimeSeries.range_min.label("min"),
-            DataFileVariableDSGTimeSeries.range_max.label("max"),
+            DataFileVariableGridded.range_min.label("min"),
+            DataFileVariableGridded.range_max.label("max"),
         )
         joins = (DataFile,)
 
@@ -214,7 +214,7 @@ class RasterMetadata(object):
             q = (
                 sesh.query(*columns)
                 .filter(DataFile.unique_id == unique_id)
-                .filter(DataFileVariableDSGTimeSeries.netcdf_variable_name == var)
+                .filter(DataFileVariableGridded.netcdf_variable_name == var)
             )
             for Table in joins:
                 q = q.join(Table)
@@ -299,7 +299,7 @@ def db_raster_configurator(session, name, version, api_version, ensemble, root_u
 def ensemble_files(session, ensemble_name):
     q = (
         session.query(DataFile)
-        .join(DataFileVariableDSGTimeSeries)
+        .join(DataFileVariableGridded)
         .join(EnsembleDataFileVariables)
         .join(Ensemble)
         .filter(Ensemble.name == ensemble_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,9 @@ from modelmeta import (
     Model,
     Emission,
     Run,
+    Grid,
     DataFile,
-    DataFileVariableDSGTimeSeries,
+    DataFileVariableGridded,
     VariableAlias,
     Ensemble,
 )
@@ -218,8 +219,23 @@ def make_variable_alias(i):
     )
 
 
-def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
-    return DataFileVariableDSGTimeSeries(
+def make_grid(i):
+    return Grid(
+        name="Grid {}".format(i),
+        evenly_spaced_y=True,
+        xc_count=99,
+        xc_grid_step=99,
+        xc_origin=99,
+        xc_units="furlong",
+        yc_count=99,
+        yc_grid_step=99,
+        yc_origin=99,
+        yc_units="furlong",
+    )
+
+
+def make_dfv_gridded(i, file=None, variable_alias=None, grid=None):
+    return DataFileVariableGridded(
         derivation_method=f"derivation_method_{i}",
         variable_cell_methods=f"variable_cell_methods_{i}",
         netcdf_variable_name=f"var_{i}",
@@ -228,6 +244,7 @@ def make_dfv_dsg_time_series(i, file=None, variable_alias=None):
         range_max=100,
         file=file,
         variable_alias=variable_alias,
+        grid=grid,
     )
 
 
@@ -298,14 +315,20 @@ def variable_aliases():
 
 
 @pytest.fixture(scope="function")
-def dfv_dsg_tss(data_files, variable_aliases):
+def grids():
+    return make(make_grid, 1)
+
+
+@pytest.fixture(scope="function")
+def dfv_dsg_tss(data_files, variable_aliases, grids):
+    grid = grids[0]
     return make(
-        make_dfv_dsg_time_series,
+        make_dfv_gridded,
         [
-            (data_files[0], variable_aliases[0]),  # var 0, uid 0
-            (data_files[0], variable_aliases[1]),  # var 1, uid 0
-            (data_files[1], variable_aliases[1]),  # var 2, uid 1
-            (data_files[2], variable_aliases[1]),  # var 3, uid 2
+            (data_files[0], variable_aliases[0], grid),  # var 0, uid 0
+            (data_files[0], variable_aliases[1], grid),  # var 1, uid 0
+            (data_files[1], variable_aliases[1], grid),  # var 2, uid 1
+            (data_files[2], variable_aliases[1], grid),  # var 3, uid 2
         ],
     )
 


### PR DESCRIPTION
This branch copies [this bugfix](https://github.com/pacificclimate/pdp_util/pull/34), made by @rod-glover , to the python 3 version of pdp_util (and extends it in a couple places where necessary). 

I also checked the following three bugfixes made by @jameshiebert , and discovered they were all already in the python 3 version and do not need to be duplicated:

* [duplicate zipfile bugfix](https://github.com/pacificclimate/pdp_util/commit/23c45e7145b366ef5b4f22ec99d139b3a1eb97b1)
* [unpublished network bugfix](https://github.com/pacificclimate/pdp_util/commit/e2b1f80b3556a959643215938ea5b5c574072bc5)
* [single POLYGON selection bugfix](https://github.com/pacificclimate/pdp_util/commit/2e86e38bebae08f2fcef2def6d410bb22ed3e733)