### PR TITLE
Update postgresql-14 version in CI testing

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,7 +40,7 @@ jobs:
           # The version of postgresql-14 may periodically require updating. To find out what
           # it must be upgraded to, comment out the following line and read the error message
           # that results. For more info, see above. (This is a grim procedure.)
-          # sudo apt-get install -yq --allow-downgrades postgresql-14=14.12-0ubuntu0.22.04.1
+          sudo apt-get install -yq --allow-downgrades postgresql-14=14.13-0ubuntu0.22.04.1
           echo "installing postgresql-14-postgis-3"
           sudo apt-get install -yq postgresql-14-postgis-3
           echo "installing postgresql-plpython3-14"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,7 +40,7 @@ jobs:
           # The version of postgresql-14 may periodically require updating. To find out what
           # it must be upgraded to, comment out the following line and read the error message
           # that results. For more info, see above. (This is a grim procedure.)
-          sudo apt-get install -yq --allow-downgrades postgresql-14=14.12-0ubuntu0.22.04.1
+          # sudo apt-get install -yq --allow-downgrades postgresql-14=14.12-0ubuntu0.22.04.1
           echo "installing postgresql-14-postgis-3"
           sudo apt-get install -yq postgresql-14-postgis-3
           echo "installing postgresql-plpython3-14"


### PR DESCRIPTION
Followed the extremely helpful directions in [python-ci.yml](https://github.com/pacificclimate/pdp_util/blob/master/.github/workflows/python-ci.yml) to update the install postgresql14 version after CI testing began returning installation errors.